### PR TITLE
ER図のlegendを更新

### DIFF
--- a/stencils/er.iuml
+++ b/stencils/er.iuml
@@ -5,10 +5,10 @@ skinparam LineType ortho
 legend top left
     凡例
     |= 説明 |= 記号 |
-    | 0 or 1 | <transparent> --o\| |
-    | 1のみ  | <transparent> --\|\| |
-    | 0以上  | <transparent> --o{ |
-    | 1以上  | <transparent> --\|{ |
+    | 0 or 1 | --o\| |
+    | 1のみ  | --\|\| |
+    | 0以上  | --o{ |
+    | 1以上  | --\|{ |
     ----
     M = Master
     T = Transaction


### PR DESCRIPTION
`<transparent>` は使えなかったので削除